### PR TITLE
Show the current version/build in the navigation slider

### DIFF
--- a/camblms.fsproj
+++ b/camblms.fsproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>6.0</LangVersion>
+    <Version>0.6.0</Version>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="src/server/RandomString.fs" />
@@ -80,6 +82,19 @@
     <Content Include="basedb.sql" CopyToPublishDirectory="Always" />
     <Content Include="templates/**/*.*" CopyToPublishDirectory="Always" />
   </ItemGroup>
+
+  <PropertyGroup>
+     <GitVersion>false</GitVersion>
+  </PropertyGroup>
+
+  <Choose>
+  <When Condition="'$(Configuration)' == 'Debug' ">
+    <ItemGroup>
+      <PackageReference Include="GitInfo" Version="3.5.0" PrivateAssets="all" />
+    </ItemGroup>
+  </When>
+  </Choose>
+
   <ItemGroup>
     <PackageReference Include="MySQL.Data" Version="8.4.0" />
     <PackageReference Include="SQLProvider" Version="1.3.47" />
@@ -90,4 +105,24 @@
     <PackageReference Include="WebSharper.AspNetCore" Version="6.1.7.476" />
     <PackageReference Update="FSharp.Core" Version="6.0.7" />
   </ItemGroup>
+  <Target Name="PopulateInfo" DependsOnTargets="GitVersion" Condition="'$(Configuration)' == 'Debug' " BeforeTargets="GetAssemblyVersion;GenerateNuspec;GetPackageContents">
+  <Exec Command="git config user.name" ConsoleToMSBuild="true">
+  <Output TaskParameter="ConsoleOutput" PropertyName="GitUser" />
+  </Exec>
+  <PropertyGroup>
+        <PackageVersion>$(Version)</PackageVersion>
+        <RepositoryBranch>$(GitBranch)</RepositoryBranch>
+        <RepositoryCommit>$(GitCommit)</RepositoryCommit>
+        <SourceRevisionId>$(GitBranch) $(GitCommit)</SourceRevisionId>
+        <InformationalVersion>$(GitBranch) - $(GitCommit) - $([System.DateTime]::Now.ToString("yyyyMMddHHmm")) - $(GitUser)</InformationalVersion>
+      </PropertyGroup>
+  </Target>
+  <Choose>
+    <When Condition=" '$(Configuration)'=='Release' ">
+      <PropertyGroup>
+        <InformationalVersion>$(Version)</InformationalVersion>
+        <PackageVersion>$(Version)</PackageVersion>
+      </PropertyGroup>
+    </When>
+  </Choose>
 </Project>

--- a/src/server/routing/PageMaker.fs
+++ b/src/server/routing/PageMaker.fs
@@ -1,8 +1,8 @@
 namespace camblms.server.routing
 
-open WebSharper
+open System.Reflection
+
 open WebSharper.UI
-open WebSharper.UI.Html
 open WebSharper.Sitelets
 
 open camblms.dto
@@ -21,118 +21,88 @@ module PageMakers =
         else if cookieValue.Value.Equals "dark" then "dark-mode"
         else "light-mode"
 
-    let RegistrationAdmin ctx ep (name: string) =
+    let versionInfo =
+        let infVersionType = typedefof<AssemblyInformationalVersionAttribute>
+        Assembly.GetCallingAssembly()
+            .GetCustomAttributes(infVersionType,false)
+        |> Seq.item 0 :?> AssemblyInformationalVersionAttribute
+
+    let buildMainTemplate ctx ep (name: string) isAdmin =
         SiteTemplates
             .MainTemplate()
             .DarkMode(getDarkModeStatus ctx)
-            .Navbar(Navbar.MakeNavbar ctx ep true)
+            .Navbar(Navbar.MakeNavbar ctx ep isAdmin)
+            .FirstName(name)
+            .VersionString(versionInfo.InformationalVersion)
+
+    let RegistrationAdmin ctx ep (name: string) =
+        (buildMainTemplate ctx ep name true)
             .ErrorBox(SiteTemplates.MainTemplate.ErrorMessageBox().Doc())
             .SuccessBox(SiteTemplates.MainTemplate.SuccessMessageBox().Doc())
-            .FirstName(name)
             .Main(ClientServer.client (RegistrationAdminPage.RenderPage()))
             .Doc()
 
     let PasswordChange ctx ep (name: string) =
-        SiteTemplates
-            .MainTemplate()
-            .DarkMode(getDarkModeStatus ctx)
-            .Navbar(Navbar.MakeNavbar ctx ep false)
+        (buildMainTemplate ctx ep name false)
             .ErrorBox(SiteTemplates.MainTemplate.ErrorMessageBox().Doc())
             .SuccessBox(SiteTemplates.MainTemplate.SuccessMessageBox().Doc())
-            .FirstName(name)
             .Main(ClientServer.client (PasswordChangePage.RenderPage()))
             .Doc()
 
     let NameChange ctx ep (name: string) =
-        SiteTemplates
-            .MainTemplate()
-            .DarkMode(getDarkModeStatus ctx)
-            .Navbar(Navbar.MakeNavbar ctx ep false)
-            .FirstName(name)
+        (buildMainTemplate ctx ep name false)
             .ErrorBox(SiteTemplates.MainTemplate.ErrorMessageBox().Doc())
             .SuccessBox(SiteTemplates.MainTemplate.SuccessMessageBox().Doc())
             .Main(ClientServer.client (NameChangePage.RenderPage()))
             .Doc()
 
     let MembersAdmin ctx ep (user: Member) (name: string) =
-        SiteTemplates
-            .MainTemplate()
-            .DarkMode(getDarkModeStatus ctx)
-            .Navbar(Navbar.MakeNavbar ctx ep true)
+        (buildMainTemplate ctx ep name true)
             .ErrorBox(SiteTemplates.MainTemplate.ErrorMessageBox().Doc())
             .SuccessBox(SiteTemplates.MainTemplate.SuccessMessageBox().Doc())
-            .FirstName(name)
             .Main(ClientServer.client (MemberAdminPage.RenderPage user))
             .Doc()
 
     let Changelog ctx ep (name: string) =
-        SiteTemplates
-            .MainTemplate()
-            .DarkMode(getDarkModeStatus ctx)
-            .Navbar(Navbar.MakeNavbar ctx ep false)
-            .FirstName(name)
+        (buildMainTemplate ctx ep name false)
             .Main(SiteParts.ChangelogTemplate().Doc())
             .Doc()
 
     let CarsAdmin ctx ep (name: string) =
-        SiteTemplates
-            .MainTemplate()
-            .DarkMode(getDarkModeStatus ctx)
-            .Navbar(Navbar.MakeNavbar ctx ep true)
+        (buildMainTemplate ctx ep name true)
             .ErrorBox(SiteTemplates.MainTemplate.ErrorMessageBox().Doc())
             .SuccessBox(SiteTemplates.MainTemplate.SuccessMessageBox().Doc())
-            .FirstName(name)
             .Main(ClientServer.client (CarsAdmin.RenderPage()))
             .Doc()
 
     let Information ctx ep (name: string) =
-        SiteTemplates
-            .MainTemplate()
-            .DarkMode(getDarkModeStatus ctx)
-            .Navbar(Navbar.MakeNavbar ctx ep false)
-            .FirstName(name)
+        (buildMainTemplate ctx ep name false)
             .Main(ClientServer.client (Information.RenderPage()))
             .Doc()
 
     let Taxi ctx ep (name: string) =
-        SiteTemplates
-            .MainTemplate()
-            .DarkMode(getDarkModeStatus ctx)
-            .Navbar(Navbar.MakeNavbar ctx ep false)
-            .FirstName(name)
+        (buildMainTemplate ctx ep name false)
             .ErrorBox(SiteTemplates.MainTemplate.ErrorMessageBox().Doc())
             .SuccessBox(SiteTemplates.MainTemplate.SuccessMessageBox().Doc())
             .Main(ClientServer.client (TaxiPage.RenderPage()))
             .Doc()
 
     let Towing ctx ep (name: string) =
-        SiteTemplates
-            .MainTemplate()
-            .DarkMode(getDarkModeStatus ctx)
-            .Navbar(Navbar.MakeNavbar ctx ep false)
-            .FirstName(name)
+        (buildMainTemplate ctx ep name false)
             .ErrorBox(SiteTemplates.MainTemplate.ErrorMessageBox().Doc())
             .SuccessBox(SiteTemplates.MainTemplate.SuccessMessageBox().Doc())
             .Main(ClientServer.client (TowPage.RenderPage()))
             .Doc()
 
     let AdminHome ctx ep (name: string) =
-        SiteTemplates
-            .MainTemplate()
-            .DarkMode(getDarkModeStatus ctx)
-            .Navbar(Navbar.MakeNavbar ctx ep true)
-            .FirstName(name)
+        (buildMainTemplate ctx ep name true)
             .ErrorBox(SiteTemplates.MainTemplate.ErrorMessageBox().Doc())
             .SuccessBox(SiteTemplates.MainTemplate.SuccessMessageBox().Doc())
             .Main(ClientServer.client (AdminHome.RenderPage()))
             .Doc()
 
     let ServiceAdmin ctx ep (name: string) =
-        SiteTemplates
-            .MainTemplate()
-            .DarkMode(getDarkModeStatus ctx)
-            .FirstName(name)
-            .Navbar(Navbar.MakeNavbar ctx ep true)
+        (buildMainTemplate ctx ep name true)
             .ErrorBox(SiteTemplates.MainTemplate.ErrorMessageBox().Doc())
             .SuccessBox(SiteTemplates.MainTemplate.SuccessMessageBox().Doc())
             .Main(ClientServer.client (ServiceFeeAdmin.RenderPage()))
@@ -147,33 +117,21 @@ module PageMakers =
             .Doc()
 
     let InactivityPage ctx ep (name: string) =
-        SiteTemplates
-            .MainTemplate()
-            .DarkMode(getDarkModeStatus ctx)
-            .Navbar(Navbar.MakeNavbar ctx ep false)
+        (buildMainTemplate ctx ep name false)
             .ErrorBox(SiteTemplates.MainTemplate.ErrorMessageBox().Doc())
             .SuccessBox(SiteTemplates.MainTemplate.SuccessMessageBox().Doc())
-            .FirstName(name)
             .Main(ClientServer.client (InactivityPage.RenderPage()))
             .Doc()
 
     let InactivityAdmin ctx ep (name: string) =
-        SiteTemplates
-            .MainTemplate()
-            .DarkMode(getDarkModeStatus ctx)
-            .Navbar(Navbar.MakeNavbar ctx ep true)
-            .FirstName(name)
+        (buildMainTemplate ctx ep name true)
             .ErrorBox(SiteTemplates.MainTemplate.ErrorMessageBox().Doc())
             .SuccessBox(SiteTemplates.MainTemplate.SuccessMessageBox().Doc())
             .Main(ClientServer.client (InactivityAdmin.RenderPage()))
             .Doc()
 
     let DocAdmin ctx ep (name: string) =
-        SiteTemplates
-            .MainTemplate()
-            .DarkMode(getDarkModeStatus ctx)
-            .Navbar(Navbar.MakeNavbar ctx ep true)
-            .FirstName(name)
+        (buildMainTemplate ctx ep name true)
             .ErrorBox(SiteTemplates.MainTemplate.ErrorMessageBox().Doc())
             .SuccessBox(SiteTemplates.MainTemplate.SuccessMessageBox().Doc())
             .Main(ClientServer.client (DocAdmin.RenderPage()))
@@ -197,19 +155,12 @@ module PageMakers =
             .Doc()
 
     let SettingsPage (ctx: Context<EndPoint>) ep (name: string) (user: Member) =
-        SiteTemplates
-            .MainTemplate()
-            .DarkMode(getDarkModeStatus ctx)
-            .FirstName(name)
-            .Navbar(Navbar.MakeNavbar ctx ep false)
+        (buildMainTemplate ctx ep name false)
             .Main(ClientServer.client (SettingsPage.RenderPage()))
             .Doc()
 
     let DocumentPage (ctx: Context<EndPoint>) ep (name: string) (user: Member) =
-        SiteTemplates
-            .MainTemplate()
-            .DarkMode(getDarkModeStatus ctx)
-            .FirstName(name)
+        (buildMainTemplate ctx ep name false)
             .ErrorBox(
                 match ctx.Request.Get.Item "success" with
                 | Some s ->
@@ -236,7 +187,6 @@ module PageMakers =
                         SiteTemplates.MainTemplate.SuccessMessageBox().Doc()
                 | None -> SiteTemplates.MainTemplate.SuccessMessageBox().Doc()
             )
-            .Navbar(Navbar.MakeNavbar ctx ep false)
             .Main(
                 SiteParts
                     .DocumentsTemplate()
@@ -257,11 +207,7 @@ module PageMakers =
             .Doc()
 
     let ImageUpload ctx ep (name: string) =
-        SiteTemplates
-            .MainTemplate()
-            .DarkMode(getDarkModeStatus ctx)
-            .FirstName(name)
-            .Navbar(Navbar.MakeNavbar ctx ep false)
+        (buildMainTemplate ctx ep name false)
             .ErrorBox(
                 match ctx.Request.Get.Item "success" with
                 | Some s ->

--- a/templates/wrappers/main.html
+++ b/templates/wrappers/main.html
@@ -74,6 +74,9 @@
             <a ws-template="NavbarLogout" href="${Url}" class="cl-bar-item cl-button cl-padding cl-hover-red"><i class="fa fa-sign-out"></i> ${ItemTitle}</a>
             <a ws-template="NavbarDarkToggle" href="#" onclick="toggle_dark_mode()" class="cl-bar-item cl-button cl-padding"><i class="fa fa-moon-o"></i> Világos/sötét mód</a>
         </div>
+        <div class="cl-bottom" style="width: 300px; word-wrap:break-word; padding-left: 5px; padding-bottom: 15px;">
+            <span>CambLMS ${VersionString}</span>
+        </div>
     </nav>
 
 


### PR DESCRIPTION
This helps distinguish between the different versions used when someone's running more than one version at the same time.

The displayed version string is as follows:
- Release builds: *major.minor.patch*
- Debug builds: *branch - commit - build date in yyMMddHHmm format - Git user name *

Navigation menu with the version string:
![Screenshot_20241104_195729](https://github.com/user-attachments/assets/adfa78e0-cb7b-4693-9508-2f4662972df1)



